### PR TITLE
Renaming read only and smart contract functions for mining

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -6,7 +6,7 @@ import { connectAction, disconnectAction, updateUserRoleAction } from '../redux/
 import { selectCurrentTheme, selectCurrentUserRole, selectUserSessionState } from '../redux/reducers/user-state';
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { readOnlyAddressStatus } from '../consts/readOnly';
+import { readOnlyAddressStatusMining } from '../consts/readOnly';
 
 interface ConnectWalletProps {
   currentTheme: string;
@@ -33,7 +33,7 @@ const ConnectWallet = ({ currentTheme }: ConnectWalletProps) => {
     const fetchStatus = async () => {
       if (userSession.isUserSignedIn()) {
         const args = userSession.loadUserData().profile.stxAddress.testnet;
-        const status = await readOnlyAddressStatus(args);
+        const status = await readOnlyAddressStatusMining(args);
         setFinalStatus(status);
         updateUserRoleAction(finalStatus);
       }

--- a/src/components/appMenuSections/dashboard/Dashboard.tsx
+++ b/src/components/appMenuSections/dashboard/Dashboard.tsx
@@ -7,10 +7,10 @@ import {
 } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
 import {
-  readOnlyGetBlocksWon,
+  readOnlyGetBlocksWonMining,
   ReadOnlyGetMinersList,
   readOnlyGetNotifier,
-  readOnlyGetStacksRewards,
+  readOnlyGetStacksRewardsMining,
 } from '../../../consts/readOnly';
 import DashboardInfoContainer from '../../reusableComponents/dashboard/DashboardInfoContainer';
 import colors from '../../../consts/colorPallete';
@@ -59,7 +59,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     const getBlocksWon = async () => {
-      const blocks = await readOnlyGetBlocksWon();
+      const blocks = await readOnlyGetBlocksWonMining();
       setBlocksWon(blocks);
     };
     getBlocksWon();
@@ -67,7 +67,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     const getStacksRewards = async () => {
-      const stacks = await readOnlyGetStacksRewards();
+      const stacks = await readOnlyGetStacksRewardsMining();
       setStacksRewards(stacks);
     };
     getStacksRewards();

--- a/src/components/appMenuSections/miningPool/MiningPool.tsx
+++ b/src/components/appMenuSections/miningPool/MiningPool.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import TableCell from '@mui/material/TableCell';
 import Box from '@mui/material/Box';
 import colors from '../../../consts/colorPallete';
-import { ContractProposeRemoval } from '../../../consts/smartContractFunctions';
+import { ContractProposeRemovalMining } from '../../../consts/smartContractFunctions';
 import Button from '@mui/material/Button';
 import TableCreation from '../../../components/TableCreation';
 import PersonRemoveIcon from '@mui/icons-material/PersonRemove';
@@ -20,7 +20,7 @@ const MiningPool = () => {
 
   const handleMinerRemoveButtonClick = (address: string | undefined) => {
     if (address !== undefined) {
-      ContractProposeRemoval(address);
+      ContractProposeRemovalMining(address);
     }
   };
 

--- a/src/components/appMenuSections/miningPool/MiningPoolStatus.tsx
+++ b/src/components/appMenuSections/miningPool/MiningPoolStatus.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
-  readOnlyGetBlocksWon,
-  readOnlyGetCurrentBlock,
+  readOnlyGetBlocksWonMining,
+  readOnlyGetCurrentBlockMining,
   readOnlyGetNotifier,
   readOnlyGetNotifierElectionProcessData,
 } from '../../../consts/readOnly';
@@ -19,7 +19,7 @@ const MiningPoolStatus = () => {
 
   useEffect(() => {
     const getBlocksWon = async () => {
-      const blocks = await readOnlyGetBlocksWon();
+      const blocks = await readOnlyGetBlocksWonMining();
       setBlocksWon(blocks);
     };
     getBlocksWon();
@@ -50,7 +50,7 @@ const MiningPoolStatus = () => {
 
   useEffect(() => {
     const getCurrentBlock = async () => {
-      const block = await readOnlyGetCurrentBlock();
+      const block = await readOnlyGetCurrentBlockMining();
       setCurrentBlock(block);
     };
     getCurrentBlock();

--- a/src/components/appMenuSections/profile/MinerProfile.tsx
+++ b/src/components/appMenuSections/profile/MinerProfile.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import {
-  readOnlyGetAllTotalWithdrawals,
+  readOnlyGetAllTotalWithdrawalsMining,
   ReadOnlyAllDataWaitingMiners,
-  readOnlyGetRemainingBlocksJoin,
+  readOnlyGetRemainingBlocksJoinMining,
 } from '../../../consts/readOnly';
 import { selectCurrentUserRole, selectUserSessionState } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
@@ -39,7 +39,7 @@ const MinerProfile = ({
 
   useEffect(() => {
     const fetchBlocksLeft = async () => {
-      const blocksLeft = await readOnlyGetRemainingBlocksJoin();
+      const blocksLeft = await readOnlyGetRemainingBlocksJoinMining();
       setBlocksLeftUntilJoin(blocksLeft);
     };
     fetchBlocksLeft();
@@ -48,7 +48,7 @@ const MinerProfile = ({
   useEffect(() => {
     const getUserTotalWithdrawls = async () => {
       const principalAddress = userSession.loadUserData().profile.stxAddress.testnet;
-      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawals(principalAddress);
+      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawalsMining(principalAddress);
       setTotalWithdrawals(getTotalWithdrawals);
     };
 

--- a/src/components/appMenuSections/profile/MinerProfileDetails.tsx
+++ b/src/components/appMenuSections/profile/MinerProfileDetails.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import {
   ReadOnlyAllDataWaitingMiners,
-  readOnlyAddressStatus,
+  readOnlyAddressStatusMining,
   readOnlyGetAllDataMinersInPool,
-  readOnlyGetRemainingBlocksJoin,
+  readOnlyGetRemainingBlocksJoinMining,
 } from '../../../consts/readOnly';
 import { getExplorerUrl, network } from '../../../consts/network';
 import { cvToJSON, listCV, principalCV } from '@stacks/transactions';
@@ -45,7 +45,7 @@ const MinerProfileDetails = () => {
   useEffect(() => {
     if (status === 'Pending') {
       const fetchBlocksLeft = async () => {
-        const blocksLeft = await readOnlyGetRemainingBlocksJoin();
+        const blocksLeft = await readOnlyGetRemainingBlocksJoinMining();
         setBlocksLeftUntilJoin(blocksLeft);
       };
       fetchBlocksLeft();
@@ -71,7 +71,7 @@ const MinerProfileDetails = () => {
       setExplorerLink(getExplorerUrl[network](address).explorerUrl);
 
       const getAddressStatus = async () => {
-        const newStatus = await readOnlyAddressStatus(address);
+        const newStatus = await readOnlyAddressStatusMining(address);
         setStatus(newStatus);
       };
       getAddressStatus();

--- a/src/components/appMenuSections/profile/PendingMinerProfile.tsx
+++ b/src/components/appMenuSections/profile/PendingMinerProfile.tsx
@@ -3,7 +3,7 @@ import { Box } from '@mui/material';
 import { useAppSelector } from '../../../redux/store';
 import { selectCurrentTheme, selectCurrentUserRole } from '../../../redux/reducers/user-state';
 import { useEffect, useState } from 'react';
-import { readOnlyGetRemainingBlocksJoin } from '../../../consts/readOnly';
+import { readOnlyGetRemainingBlocksJoinMining } from '../../../consts/readOnly';
 import { ContractAddPending } from '../../../consts/smartContractFunctions';
 
 const PendingMinerProfile = () => {

--- a/src/components/appMenuSections/profile/Profile.tsx
+++ b/src/components/appMenuSections/profile/Profile.tsx
@@ -15,7 +15,11 @@ import MinerProfile from './MinerProfile';
 import colors from '../../../consts/colorPallete';
 import { useEffect, useState } from 'react';
 import { network, getExplorerUrl } from '../../../consts/network';
-import { readOnlyGetAllTotalWithdrawals, readOnlyGetBalance, readOnlyGetNotifier } from '../../../consts/readOnly';
+import {
+  readOnlyGetAllTotalWithdrawalsMining,
+  readOnlyGetBalanceMining,
+  readOnlyGetNotifier,
+} from '../../../consts/readOnly';
 
 const Profile = () => {
   const currentRole: UserRole = useAppSelector(selectCurrentUserRole);
@@ -101,8 +105,8 @@ const Profile = () => {
   useEffect(() => {
     const getUserBalance = async () => {
       const principalAddress = userSession.loadUserData().profile.stxAddress.testnet;
-      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawals(principalAddress);
-      const balance = await readOnlyGetBalance(principalAddress);
+      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawalsMining(principalAddress);
+      const balance = await readOnlyGetBalanceMining(principalAddress);
       setTotalWithdrawals(getTotalWithdrawals);
       setCurrentBalance(balance);
     };

--- a/src/components/appMenuSections/profile/WaitingMinerProfile.tsx
+++ b/src/components/appMenuSections/profile/WaitingMinerProfile.tsx
@@ -2,7 +2,7 @@ import colors from '../../../consts/colorPallete';
 import { Box, Button } from '@mui/material';
 import { useAppSelector } from '../../../redux/store';
 import { selectCurrentTheme, selectCurrentUserRole, selectUserSessionState } from '../../../redux/reducers/user-state';
-import { ContractTryEnterPool } from '../../../consts/smartContractFunctions';
+import { ContractTryEnterPoolMining } from '../../../consts/smartContractFunctions';
 import { ReadOnlyAllDataWaitingMiners } from '../../../consts/readOnly';
 import { useState, useEffect } from 'react';
 import { principalCV, ClarityValue, listCV, cvToJSON } from '@stacks/transactions';

--- a/src/components/appMenuSections/voting/VotingJoiners.tsx
+++ b/src/components/appMenuSections/voting/VotingJoiners.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TableCell from '@mui/material/TableCell';
 import Box from '@mui/material/Box';
 import colors from '../../../consts/colorPallete';
-import { ContractVotePositiveJoin, ContractVoteNegativeJoin } from '../../../consts/smartContractFunctions';
+import { ContractVotePositiveJoinMining, ContractVoteNegativeJoinMining } from '../../../consts/smartContractFunctions';
 import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
 import ThumbDownAltIcon from '@mui/icons-material/ThumbDownAlt';
 import Button from '@mui/material/Button';
@@ -22,9 +22,9 @@ const VotingJoiners = () => {
   const handlePendingVoteButtonClick = (data: string, address: string | undefined) => {
     if (address !== undefined) {
       if (data === 'voteYes') {
-        ContractVotePositiveJoin(address);
+        ContractVotePositiveJoinMining(address);
       } else if (data === 'voteNo') {
-        ContractVoteNegativeJoin(address);
+        ContractVoteNegativeJoinMining(address);
       }
     }
   };

--- a/src/components/appMenuSections/voting/VotingNotifier.tsx
+++ b/src/components/appMenuSections/voting/VotingNotifier.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import {
   ReadOnlyGetMinersList,
   readOnlyGetAllDataNotifierVoterMiners,
-  readOnlyGetK,
+  readOnlyGetKMining,
   readOnlyGetNotifier,
   readOnlyGetNotifierElectionProcessData,
 } from '../../../consts/readOnly';
@@ -98,7 +98,7 @@ const VotingNotifier = () => {
 
   useEffect(() => {
     const getNotifierVotesThreshold = async () => {
-      const threshold = await readOnlyGetK();
+      const threshold = await readOnlyGetKMining();
       setNotifierVoteThreshold(threshold);
       setFetchedVotesThreshold(true);
     };

--- a/src/components/appMenuSections/voting/VotingRemovals.tsx
+++ b/src/components/appMenuSections/voting/VotingRemovals.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import TableCell from '@mui/material/TableCell';
 import Box from '@mui/material/Box';
 import colors from '../../../consts/colorPallete';
-import { ContractVotePositiveRemove, ContractVoteNegativeRemove } from '../../../consts/smartContractFunctions';
+import {
+  ContractVotePositiveRemoveMining,
+  ContractVoteNegativeRemoveMining,
+} from '../../../consts/smartContractFunctions';
 import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
 import ThumbDownAltIcon from '@mui/icons-material/ThumbDownAlt';
 import InfoIcon from '@mui/icons-material/Info';
@@ -22,9 +25,9 @@ const VotingRemovals = () => {
   const handleRemovalVoteButtonClick = (data: string, address: string | undefined) => {
     if (address !== undefined) {
       if (data === 'voteYes') {
-        ContractVotePositiveRemove(address);
+        ContractVotePositiveRemoveMining(address);
       } else if (data === 'voteNo') {
-        ContractVoteNegativeRemove(address);
+        ContractVoteNegativeRemoveMining(address);
       }
     }
   };

--- a/src/components/reusableComponents/dashboard/DashboardInfoContainer.tsx
+++ b/src/components/reusableComponents/dashboard/DashboardInfoContainer.tsx
@@ -3,7 +3,7 @@ import '../../../css/buttons/styles.css';
 import '../../../css/common-page-alignments/styles.css';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import colors from '../../../consts/colorPallete';
-import { ContractAskToJoin } from '../../../consts/smartContractFunctions';
+import { ContractAskToJoinMining } from '../../../consts/smartContractFunctions';
 import { selectCurrentTheme, UserRole } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
 
@@ -79,7 +79,7 @@ const DashboardInfoContainer = ({
             className={appCurrentTheme === 'light' ? 'customButton' : 'customDarkButton'}
             onClick={() => {
               if (userAddress !== null) {
-                ContractAskToJoin(`${userAddress}`);
+                ContractAskToJoinMining(`${userAddress}`);
               }
             }}
           >

--- a/src/components/reusableComponents/profile/ActionsContainer.tsx
+++ b/src/components/reusableComponents/profile/ActionsContainer.tsx
@@ -2,13 +2,13 @@ import './styles.css';
 import colors from '../../../consts/colorPallete';
 import { useEffect, useState } from 'react';
 import {
-  ContractWithdrawSTX,
-  ContractLeavePool,
-  ContractDepositSTX,
-  ContractRewardDistribution,
-  ContractChangeBtcAddress,
+  ContractWithdrawSTXMining,
+  ContractLeavePoolMining,
+  ContractDepositSTXMining,
+  ContractRewardDistributionMining,
+  ContractChangeBtcAddressMining,
 } from '../../../consts/smartContractFunctions';
-import { readOnlyClaimedBlockStatus, readOnlyGetAllTotalWithdrawals } from '../../../consts/readOnly';
+import { readOnlyClaimedBlockStatusMining, readOnlyGetAllTotalWithdrawalsMining } from '../../../consts/readOnly';
 import { useAppSelector } from '../../../redux/store';
 import { selectCurrentTheme, selectUserSessionState } from '../../../redux/reducers/user-state';
 import { Alert } from '@mui/material';
@@ -33,15 +33,15 @@ const ActionsContainer = ({ currentNotifier, userAddress }: IActionsContainerPro
 
   const changeBtcAddress = () => {
     if (btcAddress !== '') {
-      ContractChangeBtcAddress(btcAddress);
+      ContractChangeBtcAddressMining(btcAddress);
     }
   };
 
   const claimRewards = async () => {
     if (claimRewardsInputAmount !== null) {
-      const wasBlockClaimed = await readOnlyClaimedBlockStatus(claimRewardsInputAmount);
+      const wasBlockClaimed = await readOnlyClaimedBlockStatusMining(claimRewardsInputAmount);
       if (wasBlockClaimed === false) {
-        ContractRewardDistribution(claimRewardsInputAmount);
+        ContractRewardDistributionMining(claimRewardsInputAmount);
       } else {
         alert('Block already claimed');
       }
@@ -53,7 +53,7 @@ const ActionsContainer = ({ currentNotifier, userAddress }: IActionsContainerPro
       if (withdrawAmountInput < 0.000001) {
         alert('You need to input more');
       } else {
-        ContractWithdrawSTX(withdrawAmountInput);
+        ContractWithdrawSTXMining(withdrawAmountInput);
       }
     }
   };
@@ -64,7 +64,7 @@ const ActionsContainer = ({ currentNotifier, userAddress }: IActionsContainerPro
         alert('You need to input more');
       } else {
         console.log(depositAmountInput);
-        if (userAddress !== null) ContractDepositSTX(depositAmountInput, userAddress);
+        if (userAddress !== null) ContractDepositSTXMining(depositAmountInput, userAddress);
       }
     }
   };
@@ -72,7 +72,7 @@ const ActionsContainer = ({ currentNotifier, userAddress }: IActionsContainerPro
   const leavePool = () => {
     setLeavePoolButtonClicked(true);
     if (currentNotifier !== null && currentNotifier !== userAddress) {
-      ContractLeavePool();
+      ContractLeavePoolMining();
     } else if (currentNotifier !== null && currentNotifier === userAddress) {
       console.log("you art the notifier, you can't leave pool");
 
@@ -84,7 +84,7 @@ const ActionsContainer = ({ currentNotifier, userAddress }: IActionsContainerPro
   useEffect(() => {
     const getUserTotalWithdrawls = async () => {
       const principalAddress = userSession.loadUserData().profile.stxAddress.testnet;
-      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawals(principalAddress);
+      const getTotalWithdrawals = await readOnlyGetAllTotalWithdrawalsMining(principalAddress);
       setTotalWithdrawals(getTotalWithdrawals);
     };
 

--- a/src/components/reusableComponents/profile/MoreInfoAboutContainerMiner.tsx
+++ b/src/components/reusableComponents/profile/MoreInfoAboutContainerMiner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { readOnlyExchangeToggle } from '../../../consts/readOnly';
-import { ContractSetAutoExchange } from '../../../consts/smartContractFunctions';
+import { readOnlyExchangeToggleMining } from '../../../consts/readOnly';
+import { ContractSetAutoExchangeMining } from '../../../consts/smartContractFunctions';
 import { selectCurrentTheme } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
 
@@ -20,14 +20,14 @@ const MoreInfoAboutContainerMiner = ({
 
   const setAutoExchange = () => {
     if (userAddress !== null) {
-      ContractSetAutoExchange(!exchange);
+      ContractSetAutoExchangeMining(!exchange);
     }
   };
 
   useEffect(() => {
     const getExchangeState = async () => {
       if (userAddress !== null) {
-        const newExchange = await readOnlyExchangeToggle(userAddress);
+        const newExchange = await readOnlyExchangeToggleMining(userAddress);
         setExchange(newExchange);
       }
     };

--- a/src/components/reusableComponents/profile/MoreInfoAboutContainerWaitingMiner.tsx
+++ b/src/components/reusableComponents/profile/MoreInfoAboutContainerWaitingMiner.tsx
@@ -1,6 +1,6 @@
 import { selectCurrentTheme } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
-import { ContractTryEnterPool } from '../../../consts/smartContractFunctions';
+import { ContractTryEnterPoolMining } from '../../../consts/smartContractFunctions';
 import colors from '../../../consts/colorPallete';
 
 interface IMoreInfoAboutContainerWaitingMinerProps {
@@ -50,7 +50,7 @@ const MoreInfoAboutContainerWaitingMiner = ({
               border: `1px solid ${colors[appCurrentTheme].defaultOrange}`,
             }}
             className="customButton"
-            onClick={() => ContractTryEnterPool()}
+            onClick={() => ContractTryEnterPoolMining()}
           >
             Try Enter
           </button>

--- a/src/components/stacking/profile/StackerProfile.tsx
+++ b/src/components/stacking/profile/StackerProfile.tsx
@@ -1,14 +1,6 @@
-import { useEffect, useState } from 'react';
-import {
-  readOnlyGetAllTotalWithdrawals,
-  ReadOnlyAllDataWaitingMiners,
-  readOnlyGetRemainingBlocksJoin,
-} from '../../../consts/readOnly';
+import { useState } from 'react';
 import { selectCurrentUserRole, selectUserSessionState } from '../../../redux/reducers/user-state';
 import { useAppSelector } from '../../../redux/store';
-import AboutContainer from '../../reusableComponents/profile/AboutContainer';
-import ActionsContainer from '../../reusableComponents/profile/ActionsContainer';
-import RoleIntro from '../../reusableComponents/profile/RoleIntro';
 import { principalCV, ClarityValue, listCV, cvToJSON } from '@stacks/transactions';
 import './styles.css';
 import RoleIntroStacking from './RoleIntroStacking';

--- a/src/consts/readOnly.ts
+++ b/src/consts/readOnly.ts
@@ -37,7 +37,7 @@ const ReadOnlyFunctions = async (
 // what does it do: It returns the formatted status of the given address
 // return: 'Miner', 'Waiting', 'Pending', or 'Not Asked to Join'
 
-export const readOnlyAddressStatus = async (args: string) => {
+export const readOnlyAddressStatusMining = async (args: string) => {
   const type = 'mining';
   const statusArgs = convertPrincipalToArg(args);
 
@@ -90,7 +90,7 @@ export const ReadOnlyAllDataWaitingMiners = async (fullWaitingList: ClarityValue
 // what does it do: returns a list of miners that are proposed for removal
 // return: proposed for removal miners list
 
-export const ReadOnlyGetProposedRemovalList = async () => {
+export const ReadOnlyGetProposedRemovalListMining = async () => {
   const type = 'mining';
   const removalList: ClarityValue = await ReadOnlyFunctions(
     type,
@@ -122,7 +122,7 @@ export const ReadOnlyAllDataProposedRemovalMiners = async () => {
   const type = 'mining';
   const newResultList: RemovalsListProps[] = [];
   const newAddressList: { value: { type: string; value: string }[] }[] = [];
-  const fullRemovalsList: ClarityValue = await ReadOnlyGetProposedRemovalList();
+  const fullRemovalsList: ClarityValue = await ReadOnlyGetProposedRemovalListMining();
   const step = 1;
 
   for (
@@ -188,8 +188,8 @@ export const readOnlyGetAllDataMinersInPool = async (address: string) => {
     convertedArgs,
     functionMapping[type].readOnlyFunctions.getAllDataMinersInPool
   );
-  const withdraws = await readOnlyGetAllTotalWithdrawals(address);
-  const rawBalance = await readOnlyGetBalance(address);
+  const withdraws = await readOnlyGetAllTotalWithdrawalsMining(address);
+  const rawBalance = await readOnlyGetBalanceMining(address);
 
   if (cvToJSON(minerData).value[0].value.value === '104') {
     return 'not-a-miner';
@@ -213,7 +213,7 @@ export const readOnlyGetAllDataMinersInPool = async (address: string) => {
 // what does it do: Gets the number of blocks left until a miner can accept the users that are in pending list
 // return: Remaining blocks, number
 
-export const readOnlyGetRemainingBlocksJoin = async () => {
+export const readOnlyGetRemainingBlocksJoinMining = async () => {
   const type = 'mining';
   const blocksLeft = await ReadOnlyFunctions(
     type,
@@ -260,7 +260,7 @@ export const readOnlyGetAllDataNotifierVoterMiners = async (voterMinersList: Cla
 // what does it do: true/false if rewards on the block were claimed
 // return: true or false
 
-export const readOnlyClaimedBlockStatus = async (blockHeight: number) => {
+export const readOnlyClaimedBlockStatusMining = async (blockHeight: number) => {
   const type = 'mining';
   const convertedArgs = [uintCV(blockHeight)];
   const blockStatus = await ReadOnlyFunctions(
@@ -276,7 +276,7 @@ export const readOnlyClaimedBlockStatus = async (blockHeight: number) => {
 // what does it do: returns balance for given address
 // return: balance
 
-export const readOnlyGetBalance = async (principalAddress: string) => {
+export const readOnlyGetBalanceMining = async (principalAddress: string) => {
   const type = 'mining';
   const balanceArgs = convertPrincipalToArg(principalAddress);
   const balance = await ReadOnlyFunctions(type, [balanceArgs], functionMapping[type].readOnlyFunctions.getBalance);
@@ -288,7 +288,7 @@ export const readOnlyGetBalance = async (principalAddress: string) => {
 // what does it do: threshold for notifier votes
 // return: number
 
-export const readOnlyGetK = async () => {
+export const readOnlyGetKMining = async () => {
   const type = 'mining';
   const k = await ReadOnlyFunctions(type, [], functionMapping[type].readOnlyFunctions.getK);
   return Number(cvToJSON(k).value);
@@ -374,7 +374,7 @@ export const readOnlyGetNotifierVoteStatus = async () => {
 // what does it do: get the current block height of the Stacks blockchain
 // returns: current block
 
-export const readOnlyGetCurrentBlock = async () => {
+export const readOnlyGetCurrentBlockMining = async () => {
   const type = 'mining';
   const currentBlock = await ReadOnlyFunctions(type, [], functionMapping[type].readOnlyFunctions.getCurrentBlock);
   return cvToJSON(currentBlock).value.value;
@@ -385,7 +385,7 @@ export const readOnlyGetCurrentBlock = async () => {
 // what does it do: get the state of auto-exchange function
 // returns: boolean
 
-export const readOnlyExchangeToggle = async (args: string) => {
+export const readOnlyExchangeToggleMining = async (args: string) => {
   const type = 'mining';
   const exchangeArgs = convertPrincipalToArg(args);
   const exchange = await ReadOnlyFunctions(
@@ -402,7 +402,7 @@ export const readOnlyExchangeToggle = async (args: string) => {
 // what does it do: number of blocks won
 // returns: number
 
-export const readOnlyGetBlocksWon = async () => {
+export const readOnlyGetBlocksWonMining = async () => {
   const type = 'mining';
   const wonBlocks = await ReadOnlyFunctions(type, [], functionMapping[type].readOnlyFunctions.getBlocksWon);
   return cvToJSON(wonBlocks).value;
@@ -413,7 +413,7 @@ export const readOnlyGetBlocksWon = async () => {
 // what does it do: stacks rewards
 // returns: number
 
-export const readOnlyGetStacksRewards = async () => {
+export const readOnlyGetStacksRewardsMining = async () => {
   const type = 'mining';
   const stacksRewards = await ReadOnlyFunctions(
     type,
@@ -428,7 +428,7 @@ export const readOnlyGetStacksRewards = async () => {
 // what does it do: gets how much each address in the list has withdrawn from the sc
 // returns: number, amount
 
-export const readOnlyGetAllTotalWithdrawals = async (address: string) => {
+export const readOnlyGetAllTotalWithdrawalsMining = async (address: string) => {
   const type = 'mining';
   const convertedArgs: ClarityValue = listCV([convertPrincipalToArg(address)]);
   const totalWithdrawals = await ReadOnlyFunctions(

--- a/src/consts/smartContractFunctions.ts
+++ b/src/consts/smartContractFunctions.ts
@@ -72,7 +72,7 @@ const createPostConditionSTXTransferFromContract = (conditionAmount: number, typ
 // what does it do: When an user asks to join, they will be placed in a waiting list. With this function, you can vote for him to
 //                  join the miners list.
 
-export const ContractVotePositiveJoin = (args: string) => {
+export const ContractVotePositiveJoinMining = (args: string) => {
   const convertedArgs = [convertPrincipalToArg(args)];
   const type = 'mining';
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.votePositiveJoinRequest, []);
@@ -83,7 +83,7 @@ export const ContractVotePositiveJoin = (args: string) => {
 // what does it do: When an user asks to join, they will be placed in a waiting list. With this function, you can vote against him
 //                  joining the miners list.
 
-export const ContractVoteNegativeJoin = (args: string) => {
+export const ContractVoteNegativeJoinMining = (args: string) => {
   const convertedArgs = [convertPrincipalToArg(args)];
   const type = 'mining';
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.voteNegativeJoinRequest, []);
@@ -94,7 +94,7 @@ export const ContractVoteNegativeJoin = (args: string) => {
 // what does it do: It tries moving the user that called the function from waiting to pending list
 //                  (the user needs to pass the positive votes threshold)
 
-export const ContractTryEnterPool = () => {
+export const ContractTryEnterPoolMining = () => {
   const type = 'mining';
   CallFunctions(type, [], functionMapping[type].publicFunctions.tryEnterPool, []);
 };
@@ -103,7 +103,7 @@ export const ContractTryEnterPool = () => {
 // args: (btc-address principal)
 // what does it do: This function adds the user passed as argument to the waiting list
 
-export const ContractAskToJoin = (args: string) => {
+export const ContractAskToJoinMining = (args: string) => {
   const convertedArgs = [stringCV(args, 'ascii')];
   const type = 'mining';
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.askToJoin, []);
@@ -113,7 +113,7 @@ export const ContractAskToJoin = (args: string) => {
 // args: (amount uint)
 // what does it do: deposits stx into user's account
 
-export const ContractDepositSTX = (amount: number, userAddress: string) => {
+export const ContractDepositSTXMining = (amount: number, userAddress: string) => {
   const type = 'mining';
   const convertedArgs = [uintCV(amount * 1000000)];
   const postConditions = createPostConditionSTXTransferToContract(userAddress, amount * 1000000);
@@ -124,7 +124,7 @@ export const ContractDepositSTX = (amount: number, userAddress: string) => {
 // args: (amount uint)
 // what does it do: withdraws stx from user's account
 
-export const ContractWithdrawSTX = (amount: number) => {
+export const ContractWithdrawSTXMining = (amount: number) => {
   const type = 'mining';
   const convertedArgs = [uintCV(amount * 1000000)];
   const postConditions = createPostConditionSTXTransferFromContract(amount * 1000000, type);
@@ -135,7 +135,7 @@ export const ContractWithdrawSTX = (amount: number) => {
 // args: (block-number uint)
 // what does it do: distributes rewards for a given block
 
-export const ContractRewardDistribution = (blockHeight: number) => {
+export const ContractRewardDistributionMining = (blockHeight: number) => {
   const type = 'mining';
   const convertedArgs = [uintCV(blockHeight)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.rewardDistribution, []);
@@ -154,7 +154,7 @@ export const ContractAddPending = () => {
 // args: none
 // what does it do: makes the user leave the mining pool
 
-export const ContractLeavePool = () => {
+export const ContractLeavePoolMining = () => {
   const type = 'mining';
   CallFunctions(type, [], functionMapping[type].publicFunctions.leavePool, []);
 };
@@ -163,7 +163,7 @@ export const ContractLeavePool = () => {
 // args: (miner-to-remove principal)
 // what does it do: propose a miner to be removed from the pool
 
-export const ContractProposeRemoval = (args: string) => {
+export const ContractProposeRemovalMining = (args: string) => {
   const type = 'mining';
   const convertedArgs = [convertPrincipalToArg(args)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.proposeRemoval, []);
@@ -173,7 +173,7 @@ export const ContractProposeRemoval = (args: string) => {
 // args: (miner-to-vote principal)
 // what does it do: add 1 to the positive votes to remove the user passed as argument
 
-export const ContractVotePositiveRemove = (args: string) => {
+export const ContractVotePositiveRemoveMining = (args: string) => {
   const type = 'mining';
   const convertedArgs = [convertPrincipalToArg(args)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.votePositiveRemoveRequest, []);
@@ -183,7 +183,7 @@ export const ContractVotePositiveRemove = (args: string) => {
 // args: (miner-to-vote principal)
 // what does it do: add 1 to the negative votes to remove the user passed as argument
 
-export const ContractVoteNegativeRemove = (args: string) => {
+export const ContractVoteNegativeRemoveMining = (args: string) => {
   const type = 'mining';
   const convertedArgs = [convertPrincipalToArg(args)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.voteNegativeRemoveRequest, []);
@@ -231,7 +231,7 @@ export const ContractWarnMiner = (warnedMiner: string) => {
 // args: (new-btc-address  (string-ascii 42))
 // what does it do: changed the btc address to the one given as arg
 
-export const ContractChangeBtcAddress = (args: string) => {
+export const ContractChangeBtcAddressMining = (args: string) => {
   const type = 'mining';
   const convertedArgs = [convertStringToArg(args)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.setMyBtcAddress, []);
@@ -241,7 +241,7 @@ export const ContractChangeBtcAddress = (args: string) => {
 // args: bool value
 // what does it do: switches the state of auto-exchange to the given value
 
-export const ContractSetAutoExchange = (value: boolean) => {
+export const ContractSetAutoExchangeMining = (value: boolean) => {
   const type = 'mining';
   const convertedArgs = [boolCV(value)];
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.setAutoExchange, []);


### PR DESCRIPTION
I renamed readOnly functions and contractCall functions with "Mining" in order to be able to differentiate them from the ones I will create for stacking. The ones that are already related to mining (notifier, waiting, pending...) I didn't rename 
because there was no sense.