### PR TITLE
Rename deposit with new name

### DIFF
--- a/src/consts/contract.ts
+++ b/src/consts/contract.ts
@@ -193,7 +193,7 @@ export const functionMapping: IFunctionMapping = {
       delegateStx: 'delegate-stx',
       leavePool: 'leave-pool',
       rewardDistribution: 'reward-distribution',
-      depositStx: 'deposit-stx-SC-owner',
+      depositStx: 'deposit-stx-liquidity-provider',
       setLiquidityProvider: 'set-liquidity-provider',
       lockInPool: 'reserve-funds-future-rewards',
     },

--- a/src/consts/smartContractFunctions.ts
+++ b/src/consts/smartContractFunctions.ts
@@ -277,14 +277,13 @@ export const ContractRewardDistributionStacking = (blockHeight: number) => {
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.rewardDistribution, []);
 };
 
-// deposit-stx-SC-owner
+//deposit-stx-liquidity-provider
 // args: (amount uint)
 // what does it do: deposits stx into user's account
 
 export const ContractDepositSTXStacking = (amount: number) => {
   const type = 'stacking';
   const convertedArgs = [uintCV(amount * 1000000)];
-  // const postConditions = createPostConditionSTXTransferToContract(userAddress, amount * 1000000);
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.depositStx, []);
 };
 
@@ -305,6 +304,5 @@ export const ContractSetNewLiquidityProvider = (newProvider: string) => {
 export const ContractReserveFundsFutureRewardsStacking = (amount: number) => {
   const type = 'stacking';
   const convertedArgs = [uintCV(amount * 1000000)];
-  // const postConditions = createPostConditionSTXTransferToContract(userAddress, amount * 1000000);
   CallFunctions(type, convertedArgs, functionMapping[type].publicFunctions.lockInPool, []);
 };


### PR DESCRIPTION
I changed the name of the smart contract call of the deposit function from profile stacking because we renamed it in the backend part.